### PR TITLE
(Refactor) Login validation and Token Error Handler Logic

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -11,5 +11,4 @@ const instance = axios.create({
 export const auth = {
   getSocialLogin: (socialName, code) =>
     instance.get(`/user/login/${socialName}?code=${code}`),
-  check: () => tokenInstance.get('/user/check'),
 };

--- a/src/components/achievment/CircleProgress.js
+++ b/src/components/achievment/CircleProgress.js
@@ -92,6 +92,7 @@ const DetailPer = styled.span`
   margin-bottom: 5px;
   padding-left: 1px;
 `;
+
 CircleProgress.propTypes = {
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,

--- a/src/components/login/GoogleLogin.js
+++ b/src/components/login/GoogleLogin.js
@@ -5,7 +5,6 @@ import { useSetRecoilState } from 'recoil';
 import { authState } from '../../recoil/states/auth';
 
 import { auth } from '../../api';
-import { setCookie } from '../../utils/cookie';
 import { GoogleSymbol } from '../../assets/icons/loginSymbol';
 import { OK } from '../../constants/statusCode';
 
@@ -14,7 +13,6 @@ const GoogleLogin = () => {
   const googleLoginBtn = useRef(null);
   const socialName = 'google';
   const setAuth = useSetRecoilState(authState);
-  console.log('googleLoginRender');
 
   useEffect(() => {
     googleSDK();
@@ -33,17 +31,20 @@ const GoogleLogin = () => {
           {},
           (googleUser) => {
             async function getTokenWithGoogle() {
-              console.log(googleUser);
               try {
                 const { data } = await auth.getSocialLogin(
                   socialName,
                   googleUser.getAuthResponse().id_token,
                 );
 
-                console.log('성공', data);
-
-                window.localStorage.setItem('habitAccess', data.accessToken);
-                window.localStorage.setItem('habitRefresh', data.refreshToken);
+                window.localStorage.setItem(
+                  'habitAccessToken',
+                  data.accessToken,
+                );
+                window.localStorage.setItem(
+                  'habitRefreshToken',
+                  data.refreshToken,
+                );
 
                 if (data.statusCode === OK && data.isFirstLogin) {
                   setAuth({
@@ -63,7 +64,7 @@ const GoogleLogin = () => {
                   return;
                 }
               } catch (err) {
-                console.error(err);
+                console.error(err.response);
               }
             }
 
@@ -92,12 +93,12 @@ const GoogleLogin = () => {
   };
 
   return (
-    <React.Fragment>
+    <>
       <LoginBtn ref={googleLoginBtn} id="gSignInWrapper">
         <GoogleSymbol />
         <SocialTitle>Google로 시작하기</SocialTitle>
       </LoginBtn>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/src/components/login/KakaoLogin.js
+++ b/src/components/login/KakaoLogin.js
@@ -5,7 +5,6 @@ import { useSetRecoilState } from 'recoil';
 import { authState } from '../../recoil/states/auth';
 
 import { auth } from '../../api';
-import { setCookie } from '../../utils/cookie';
 import { KakaoSymbol } from '../../assets/icons/loginSymbol';
 import { OK } from '../../constants/statusCode';
 
@@ -24,14 +23,15 @@ const KakaoLogin = () => {
     async function getTokenWithKakao() {
       try {
         const { data } = await auth.getSocialLogin(socialName, kakaoAuthCode);
-        window.localStorage.setItem('habitAccess', data.accessToken);
-        window.localStorage.setItem('habitRefresh', data.refreshToken);
+        window.localStorage.setItem('habitAccessToken', data.accessToken);
+        window.localStorage.setItem('habitRefreshToken', data.refreshToken);
 
         if (data.statusCode === OK && data.isFirstLogin) {
           setAuth({
             isLogin: true,
             isFirstLogin: data.isFirstLogin,
           });
+          history.replace('/monster');
           return;
         }
 
@@ -40,6 +40,7 @@ const KakaoLogin = () => {
             isLogin: true,
             isFirstLogin: data.isFirstLogin,
           });
+          history.replace('/');
           return;
         }
       } catch (err) {
@@ -54,12 +55,12 @@ const KakaoLogin = () => {
   };
 
   return (
-    <React.Fragment>
+    <>
       <LoginBtn className="kakaoLogin" onClick={loginWithKakao}>
         <KakaoSymbol />
         <SocialTitle>카카오로 시작하기</SocialTitle>
       </LoginBtn>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/src/components/login/LoginTitle.js
+++ b/src/components/login/LoginTitle.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { loginMonster, titleMonster } from '../../assets/images/login';
+import { loginMonster } from '../../assets/images/login';
 
 const LoginTitle = () => {
   return (
     <Wrapper>
       <TitleContainer>
-        <TitleImage />
         <Title>Habit</Title>
         <Title>Monster</Title>
       </TitleContainer>
@@ -16,18 +15,6 @@ const LoginTitle = () => {
     </Wrapper>
   );
 };
-
-const TitleImage = styled.div`
-  position: absolute;
-  top: 100px;
-  left: 225px;
-  width: 38.8px;
-  height: 38.66px;
-  background-image: url(${titleMonster});
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: contain;
-`;
 
 const TitleContainer = styled.div`
   width: 187px;

--- a/src/components/login/NaverLogin.js
+++ b/src/components/login/NaverLogin.js
@@ -5,7 +5,6 @@ import { useSetRecoilState } from 'recoil';
 import { authState } from '../../recoil/states/auth';
 
 import { auth } from '../../api';
-import { setCookie } from '../../utils/cookie';
 import { NaverSymbol } from '../../assets/icons/loginSymbol';
 import { OK } from '../../constants/statusCode';
 
@@ -48,8 +47,8 @@ const NaverLogin = () => {
     async function getTokenWithNaver() {
       try {
         const { data } = await auth.getSocialLogin(socialName, naverAuthCode);
-        setCookie('accessToken', data.accessToken);
-        setCookie('refreshToken', data.refreshToken);
+        window.localStorage.setItem('habitAccessToken', data.accessToken);
+        window.localStorage.setItem('habitRefreshToken', data.refreshToken);
 
         if (data.statusCode === OK && data.isFirstLogin) {
           setAuth({
@@ -81,15 +80,19 @@ const NaverLogin = () => {
   };
 
   return (
-    <React.Fragment>
-      <div ref={naverRef} id="naverIdLogin"></div>
+    <>
+      <HideNaverButon ref={naverRef} id="naverIdLogin"></HideNaverButon>
       <LoginBtn className="naverLogin" onClick={handleClick}>
         <NaverSymbol />
         <SocialTitle>네이버로 시작하기</SocialTitle>
       </LoginBtn>
-    </React.Fragment>
+    </>
   );
 };
+
+const HideNaverButon = styled.div`
+  display: none;
+`;
 
 const LoginBtn = styled.div`
   display: flex;

--- a/src/components/login/SocialLogin.js
+++ b/src/components/login/SocialLogin.js
@@ -16,7 +16,6 @@ const SocialLogin = () => {
   if (isLogin) {
     return <Redirect to="/" />;
   }
-  console.log('socialLogin render');
 
   return (
     <BtnContainer>

--- a/src/components/myPage/UserInformation.js
+++ b/src/components/myPage/UserInformation.js
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { useHistory } from 'react-router-dom';
 
-import { getCookie, deleteCookie } from '../../utils/cookie';
-
 import { authState } from '../../recoil/states/auth';
 import { myPageDataState } from '../../recoil/states/user';
 
@@ -12,7 +10,6 @@ import UserInfoItem from './UserInfoItem';
 import { Modal } from '../../components/common';
 import { EditBox } from '../../components/myPage';
 import { BottomDialog } from '../dialog';
-import Notice from './Notice';
 
 const UserInformation = () => {
   const resetAuth = useResetRecoilState(authState);
@@ -62,18 +59,18 @@ const UserInformation = () => {
   );
 
   const logoutUser = () => {
-    const token = getCookie('accessToken');
+    const token = window.localStorage.getItem('habitAccessToken');
 
     if (!token) {
       <div>먼저 로그인을 해주세요!</div>;
     }
-    window.localStorage.removeItem('habitAccess');
-    window.localStorage.removeItem('habitRefresh');
-    window.localStorage.removeItem('isFirstLogin');
-    window.localStorage.removeItem('isOnboarding');
+
+    window.localStorage.removeItem('habitAccessToken');
+    window.localStorage.removeItem('habitRefreshToken');
     resetAuth();
     setIsLogoutModalOpen(false);
-    history.replace('/login', null);
+
+    history.push('/login', null);
   };
 
   const userInfoList = [

--- a/src/components/onBoard/OnBoard.js
+++ b/src/components/onBoard/OnBoard.js
@@ -2,7 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import SwiperCore, { Pagination, Navigation } from 'swiper';
+import SwiperCore, { Pagination } from 'swiper';
+
+import 'swiper/swiper.min.css';
+import 'swiper/components/pagination/pagination.min.css';
 
 import {
   onboard01,
@@ -12,11 +15,7 @@ import {
 } from '../../assets/images/onboard';
 import { BottomFixedButton } from '../common';
 
-import 'swiper/swiper.min.css';
-import 'swiper/components/pagination/pagination.min.css';
-import 'swiper/components/navigation/navigation.min.css';
-
-SwiperCore.use([Pagination, Navigation]);
+SwiperCore.use([Pagination]);
 
 const OnBoard = () => {
   const history = useHistory();
@@ -33,7 +32,9 @@ const OnBoard = () => {
           <Swiper
             className="banner"
             initialSlide={0}
-            style={{ width: '360px' }}
+            style={{
+              width: '360px',
+            }}
             navigation
             pagination={{
               clickable: true,
@@ -73,14 +74,22 @@ const OnBoardContainer = styled.div`
   width: 100%;
   height: 100%;
   background-color: var(--bg-wrapper);
+
   & .swiper-container {
     height: 200px;
   }
+
   & .swiper-pagination {
     top: 150px;
   }
+
   & .swiper-pagination-bullet {
-    background: white;
+    background: var(--color-title);
+    opacity: 1;
+
+    &.swiper-pagination-bullet-active {
+      background: var(--color-onboard);
+    }
   }
 `;
 

--- a/src/constants/statusMessage.js
+++ b/src/constants/statusMessage.js
@@ -1,0 +1,8 @@
+export const ACCESS_TOKEN_EXPIRED = 'accessToken Expired';
+export const ACCESS_TOKEN_SIGNATURE_EXCEPTION =
+  'accessToken SignatureException';
+export const ACCESS_TOKEN_MALFORMED = 'accessToken Malformed';
+export const REFRESH_TOKEN_EXPIRED = 'refreshToken Expired';
+export const REFRESH_TOKEN_SIGNATURE_EXCEPTION =
+  'refreshToken SignatureException';
+export const REFRESH_TOKEN_MALFORMED = 'refreshToken Malformed';

--- a/src/hooks/useFetchCategoryPresets.js
+++ b/src/hooks/useFetchCategoryPresets.js
@@ -8,7 +8,6 @@ import { habitsState } from '../recoil/states/habit';
 
 export default function useFetchCategoryPresets() {
   const [presets, setPresets] = useState([]);
-  console.log(presets);
   const [selectedPresetId, setSelectedPresetId] = useState(false);
   const { categoryId } = useParams();
   const history = useHistory();

--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -4,9 +4,17 @@ import {
   BAD_REQUEST,
   OK,
   UNAUTHORIZED,
-  FORBIDDEN,
+  INTERNAL_SERVER_ERROR,
 } from '../constants/statusCode';
-import { getCookie, setCookie } from '../utils/cookie';
+import {
+  ACCESS_TOKEN_EXPIRED,
+  ACCESS_TOKEN_SIGNATURE_EXCEPTION,
+  ACCESS_TOKEN_MALFORMED,
+  REFRESH_TOKEN_EXPIRED,
+  REFRESH_TOKEN_SIGNATURE_EXCEPTION,
+  REFRESH_TOKEN_MALFORMED,
+} from '../constants/statusMessage';
+import { setMoveToLoginPage } from '../utils/setMoveToLoginPage';
 
 const baseURL = process.env.REACT_APP_BASE_URL;
 const instance = axios.create({ baseURL });
@@ -15,8 +23,8 @@ const setToken = (config) => {
   config.headers['Content-Type'] = 'application/json; charset=utf-8';
   config.headers['Access-Control-Allow-Origin'] = '*';
   config.headers['Access-Control-Allow-Credentials'] = true;
-  config.headers['A-AUTH-TOKEN'] = window.localStorage.getItem('habitAccess');
-
+  config.headers['A-AUTH-TOKEN'] =
+    window.localStorage.getItem('habitAccessToken');
   config.headers.withCredentials = true;
   return config;
 };
@@ -29,37 +37,89 @@ instance.interceptors.response.use(
   },
 
   async (error) => {
-    // const { data: responseData, config: originalRequest } = error.response;
+    const { data: responseData, config: originalRequest } = error.response;
 
-    // if (responseData.statusCode === BAD_REQUEST) {
-    //   try {
-    //     const { data } = await axios({
-    //       method: 'GET',
-    //       url: `${process.env.REACT_APP_BASE_URL}user/loginCheck`,
-    //       headers: {
-    //         'Content-Type': 'application/json;charset=UTF-8',
-    //         'R-AUTH-TOKEN': `${getCookie('refreshToken')}`,
-    //       },
-    //     });
+    if (responseData.statusCode === INTERNAL_SERVER_ERROR) {
+      window.alert(INTERNAL_SERVER_ERROR);
+      setMoveToLoginPage();
+      return Promise.reject(error);
+    }
 
-    //     if (data.statusCode === OK) {
-    //       setCookie('accessToken', data.accessToken);
+    if (responseData.statusCode === UNAUTHORIZED) {
+      if (responseData.responseMessage === ACCESS_TOKEN_SIGNATURE_EXCEPTION) {
+        window.alert(ACCESS_TOKEN_SIGNATURE_EXCEPTION);
+        setMoveToLoginPage();
+        return Promise.reject(error);
+      }
 
-    //       try {
-    //         originalRequest.headers['A-AUTH-TOKEN'] = `${data.accessToken}`;
-    //         return axios(originalRequest);
-    //       } catch (error) {
-    //         return error.response.data;
-    //       }
-    //     }
-    //   } catch (error) {
-    //     if (error.response.data.statusCode === BAD_REQUEST) {
-    //       console.log(error.response);
-    //       window.location.href = '/login';
-    //       return;
-    //     }
-    //   }
-    // }
+      if (responseData.responseMessage === ACCESS_TOKEN_MALFORMED) {
+        window.alert(ACCESS_TOKEN_MALFORMED);
+        setMoveToLoginPage();
+        window.location.href = '/login';
+        return Promise.reject(error);
+      }
+    }
+
+    if (
+      responseData.statusCode === BAD_REQUEST &&
+      responseData.responseMessage === ACCESS_TOKEN_EXPIRED
+    ) {
+      window.alert(ACCESS_TOKEN_EXPIRED);
+
+      try {
+        const { data } = await axios({
+          method: 'GET',
+          url: `${process.env.REACT_APP_BASE_URL}user/loginCheck`,
+          headers: {
+            'Content-Type': 'application/json;charset=UTF-8',
+            'R-AUTH-TOKEN': `${window.localStorage.getItem(
+              'habitRefreshToken',
+            )}`,
+          },
+        });
+
+        if (data.statusCode === OK) {
+          window.alert('AccessToken Reissued Successfully');
+          window.localStorage.setItem('habitAccessToken', data.accessToken);
+          originalRequest.headers['A-AUTH-TOKEN'] = `${data.accessToken}`;
+          window.alert('Resend Original Request');
+          return axios(originalRequest);
+        }
+      } catch (error) {
+        if (
+          error.response.data.statusCode === BAD_REQUEST &&
+          error.response.data.responseMessage === REFRESH_TOKEN_EXPIRED
+        ) {
+          window.alert(REFRESH_TOKEN_EXPIRED);
+          setMoveToLoginPage();
+          return Promise.reject(error);
+        }
+
+        if (error.response.data.statusCode === UNAUTHORIZED) {
+          if (
+            error.response.data.responseMessage ===
+            REFRESH_TOKEN_SIGNATURE_EXCEPTION
+          ) {
+            window.alert(REFRESH_TOKEN_SIGNATURE_EXCEPTION);
+            setMoveToLoginPage();
+            return Promise.reject(error);
+          }
+
+          if (error.response.data.responseMessage === REFRESH_TOKEN_MALFORMED) {
+            window.alert(REFRESH_TOKEN_MALFORMED);
+            setMoveToLoginPage();
+            return Promise.reject(error);
+          }
+        }
+
+        window.alert('Unexpected Error Occured');
+        setMoveToLoginPage();
+        return Promise.reject(error);
+      }
+    }
+
+    window.alert('Unexpected Error Occured');
+    setMoveToLoginPage();
     return Promise.reject(error);
   },
 );

--- a/src/recoil/states/auth.js
+++ b/src/recoil/states/auth.js
@@ -1,5 +1,5 @@
 import { atom, selector } from 'recoil';
-import { auth } from '../../api';
+import { mainApis } from '../../api';
 
 export const loginState = atom({
   key: 'loginState',
@@ -13,19 +13,16 @@ export const asyncDefaultAuth = selector({
   get: async () => {
     const loginStatus = {};
 
-    const accessToken = window.localStorage.getItem('habitAccess');
+    const accessToken = window.localStorage.getItem('habitAccessToken');
     if (!accessToken) {
       return loginStatus;
     }
 
-    console.log('after');
-
     try {
-      const { data } = await auth.check();
+      const { data } = await mainApis.checkLogin();
       loginStatus.isFirstLogin = data.isFirstLogin;
       loginStatus.isLogin = data.isLogin;
       loginStatus.createdAt = data.createdAt;
-      console.log('createdAt', loginState);
 
       return loginStatus;
     } catch (error) {

--- a/src/recoil/states/statistic.js
+++ b/src/recoil/states/statistic.js
@@ -23,7 +23,6 @@ export const getStatistic = selector({
       const statisticResponse = await statisticApi.getStatistics(currentDate);
 
       if (statisticResponse.status === OK) {
-        console.log(statisticResponse);
         return statisticResponse.data;
       }
     } catch (err) {

--- a/src/recoil/states/user.js
+++ b/src/recoil/states/user.js
@@ -23,7 +23,6 @@ const myPageDataSelector = selector({
   get: async () => {
     try {
       const { data } = await myPageApis.loadUserData();
-      console.log('userInfo', data, data.userInfo);
       return data.userInfo;
     } catch (error) {
       throw error;
@@ -42,7 +41,6 @@ export const updateUserSelector = selectorFamily({
     if (!userName) return null;
 
     const { data } = await myPageApis.editUserName(userName);
-    console.log('updateUser', data);
     return data;
   },
 });

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -23,6 +23,7 @@ const GlobalStyle = createGlobalStyle`
     --color-deemed2: #e8e8e8;
     --color-detail: #f7f5ff;
     --color-statistics: #492cf1;
+    --color-onboard: #7d3bff;
     /* Font name */
     --font-name-apple: 'Apple SD Gothic Neo';
     /* Font size */

--- a/src/utils/appendPostPosition.js
+++ b/src/utils/appendPostPosition.js
@@ -1,10 +1,9 @@
-export const appendPostPosition = (name, type) => {
+export const appendPostPosition = (name) => {
   const isEndWithConsonant = (name) => {
     const finalCharCode = name.charCodeAt(name.length - 1);
     const finalConsonantCode = (finalCharCode - 44032) % 28;
     return finalConsonantCode !== 0;
   };
 
-  // return isEndWithConsonant(name) ? '은' : '는';
   return isEndWithConsonant(name) ? true : false;
 };

--- a/src/utils/setMoveToLoginPage.js
+++ b/src/utils/setMoveToLoginPage.js
@@ -1,0 +1,5 @@
+export const setMoveToLoginPage = () => {
+  window.localStorage.removeItem('habitAccessToken');
+  window.localStorage.removeItem('habitRefreshToken');
+  window.location.href = '/login';
+};


### PR DESCRIPTION
토큰 에러 핸들러 로직을 리팩토링 했습니다.
기존에는 쿠키에 저장되던 토큰을 로컬 스토리지에 저장되도록 했습니다.
구글 로그인에서 자동으로 쿠키에 저장하는 G_AUTHUSER_H 값이
AccessToken으로 인식되는 것 같습니다.

- 어세스 토큰 만료
  - 리프레시 토큰으로 재발급 후 API 재요청
  - 리프레시 토큰 만료 또는 위변조
    - 재로그인
 
- 어세스 토큰 손상 및 위변조
  - 재로그인

- 로그아웃 => 토큰 지우고 로그인 페이지로 이동