### PR TITLE
(Update) Follows

### DIFF
--- a/src/components/monster/MonsterListItem.js
+++ b/src/components/monster/MonsterListItem.js
@@ -3,32 +3,37 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { Profile } from '../../assets/images/placeholder';
+import { MonsterThumbnailWrapper } from './';
 
-const FollowListItem = ({ user }) => {
+const MonsterListItem = ({ user }) => {
   const { monsterName, monsterImg, monsterCode, isFollowed } = user;
+  const monsterImageAlt =
+    monsterName && monsterCode ? `${monsterName} - ${monsterCode}` : '';
 
   return (
-    <FollowListItemWrap>
-      {/* <Profile /> */}
+    <MonsterListItemWrap>
       <ProfileWrap>
         <ALink to="">
-          <Profile src={monsterImg} />
+          <MonsterThumbnailWrapper
+            imageUrl={monsterImg}
+            imageAlt={monsterImageAlt}
+          />
         </ALink>
         <TextWrap>
           <ALink to="">{monsterName}</ALink>
           <p>{monsterCode}</p>
+          <p>전체 습관 달성 1위</p>
         </TextWrap>
       </ProfileWrap>
       <FollowBtn isFollowed={isFollowed}>팔로우</FollowBtn>
-    </FollowListItemWrap>
+    </MonsterListItemWrap>
   );
 };
 
-export default FollowListItem;
+export default MonsterListItem;
 
-const FollowListItemWrap = styled.li`
-  height: 64px;
+const MonsterListItemWrap = styled.li`
+  height: 80px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -79,7 +84,7 @@ const FollowBtn = styled.button`
   text-align: center;
 `;
 
-FollowListItem.propTypes = {
+MonsterListItem.propTypes = {
   user: PropTypes.object.isRequired,
   monsterName: PropTypes.string,
   monsterImg: PropTypes.string,

--- a/src/components/monster/MonsterThumbnail.js
+++ b/src/components/monster/MonsterThumbnail.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { None } from '../../assets/images/placeholder';
 
 const MonsterThumbnail = ({ imageUrl, imageAlt, imageSize }) => {
   return (
     <>
-      <MonsterImage src={imageUrl} alt={imageAlt} size={imageSize} />
+      {imageUrl ? (
+        <MonsterImage src={imageUrl} alt={imageAlt} size={imageSize} />
+      ) : (
+        <PlaceholderImage width="100%" height="100%" />
+      )}
     </>
   );
 };
@@ -30,8 +35,13 @@ const MonsterImage = styled.img`
   height: ${({ size }) => getThumbnailSize(size).height};
 `;
 
+const PlaceholderImage = styled(None)`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+`;
+
 MonsterThumbnail.propTypes = {
-  imageUrl: PropTypes.string.isRequired,
-  imageAlt: PropTypes.string.isRequired,
+  imageUrl: PropTypes.string,
+  imageAlt: PropTypes.string,
   imageSize: PropTypes.string,
 };

--- a/src/components/monster/MonsterThumbnailWrapper.js
+++ b/src/components/monster/MonsterThumbnailWrapper.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { MonsterThumbnail } from './';
+
+const MonsterThumbnailWrapper = ({
+  imageUrl,
+  imageAlt,
+  thumbnailSize,
+  monsterLevel,
+}) => {
+  return (
+    <ThumbnailWrapper size={thumbnailSize}>
+      <MonsterThumbnail
+        imageUrl={imageUrl}
+        imageAlt={imageAlt}
+        imageSize={'small'}
+      />
+      {monsterLevel && <LevelBadge>Lv.{monsterLevel}</LevelBadge>}
+    </ThumbnailWrapper>
+  );
+};
+
+export default MonsterThumbnailWrapper;
+
+const getThumbnailSize = (size) => {
+  switch (size) {
+    case 'small':
+      return {
+        backgroundColor: 'transparent',
+        border: '1px solid rgba(248, 248, 248, 0.2)',
+        width: '80px',
+        height: '80px',
+        padding: '14px 17px',
+      };
+    default:
+      return {
+        backgroundColor: 'rgba(248, 248, 248, 0.2)',
+        border: '1px solid transparent',
+        width: '52px',
+        height: '52px',
+        padding: '0',
+      };
+  }
+};
+
+const ThumbnailWrapper = styled.div`
+  background-color: ${({ size }) => getThumbnailSize(size).backgroundColor};
+  border: ${({ size }) => getThumbnailSize(size).border};
+  border-radius: 50%;
+  padding: ${({ size }) => getThumbnailSize(size).padding};
+  position: relative;
+  width: ${({ size }) => getThumbnailSize(size).width};
+  height: ${({ size }) => getThumbnailSize(size).height};
+`;
+
+const LevelBadge = styled.span`
+  background-color: #02db26;
+  border-radius: 4px;
+  color: var(--color-white);
+  line-height: 14px;
+  font-size: var(--font-xxs);
+  font-weight: var(--weight-bold);
+  padding: 2px 4px;
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+`;
+
+MonsterThumbnailWrapper.propTypes = {
+  imageUrl: PropTypes.string,
+  imageAlt: PropTypes.string,
+  thumbnailSize: PropTypes.string,
+  monsterLevel: PropTypes.number,
+};

--- a/src/components/monster/index.js
+++ b/src/components/monster/index.js
@@ -1,13 +1,17 @@
 import MonsterThumbnail from './MonsterThumbnail';
+import MonsterThumbnailWrapper from './MonsterThumbnailWrapper';
 import LevelOneMonstersDisplay from './LevelOneMonstersDisplay';
 import LevelOneMonsterForm from './LevelOneMonsterForm';
 import MainMonster from './MainMonster';
 import LevelUp from './LevelUp';
+import MonsterListItem from './MonsterListItem';
 
 export {
   MonsterThumbnail,
+  MonsterThumbnailWrapper,
   MainMonster,
   LevelOneMonstersDisplay,
   LevelOneMonsterForm,
   LevelUp,
+  MonsterListItem,
 };

--- a/src/components/myPage/EditBox.js
+++ b/src/components/myPage/EditBox.js
@@ -25,7 +25,7 @@ const EditBox = ({
 }) => {
   //* PROP을 STATE의 DEFAULT 값으로 주는 것은 안티패턴입니다 선생님!!!!!!!!!!
   //* 이 부분 다시 체크 부탁드립니다!!!!!!!!!!!!!!!!
-  // const [originValue] = useState(editValue);
+
   const isEnabled =
     type === 'monsterName'
       ? editValue && validateMonsterName(editValue)
@@ -65,7 +65,6 @@ const EditBox = ({
           };
           setUserInfoState(newUserInfoState);
         }
-        activeToast(true);
 
         if (type === 'monsterName') {
           //메인 페이지에 몬스터의 이름을 변경해야 하므로 이것도 추가할게요!
@@ -75,6 +74,7 @@ const EditBox = ({
           refetchMonster();
         }
         closeModal();
+        activeToast(true);
         // myPageData가 먼저 갱신되면서 closeModal callback 의존성에 영향을 주기 때문에 모달을 닫고 EditValue를 하도록 한다
         setTimeout(() =>
           setEditValue((myPageData) => ({ ...myPageData, [type]: editValue })),

--- a/src/components/myPage/UserInfoItem.js
+++ b/src/components/myPage/UserInfoItem.js
@@ -89,7 +89,7 @@ const CopyWrap = styled.div`
 
 const PrivateText = styled.p`
   ${fontSize('14px')};
-  line-height: 17px;
+  line-height: 16px;
   font-weight: var(--weight-regular);
   ${whiteOpacity('0.8')};
   height: 17px;

--- a/src/components/myPage/UserInformation.js
+++ b/src/components/myPage/UserInformation.js
@@ -12,15 +12,15 @@ import { authState } from '../../recoil/states/auth';
 import { myPageDataState, userState } from '../../recoil/states/user';
 import { habitIdListState } from '../../recoil/states/habit';
 
-import UserInfoItem from './UserInfoItem';
-import { Modal } from '../../components/common';
-import { EditBox } from '../../components/myPage';
 import { BottomDialog } from '../dialog';
-import { myPageApis } from '../../api';
-import { fontSize } from '../../styles/Mixin';
+import { Modal, Toast } from '../../components/common';
+import { EditBox, UserInfoItem } from '../../components/myPage';
+import { MonsterThumbnailWrapper } from '../../components/monster';
 
+import { myPageApis } from '../../api';
 import { USER_DELETED } from '../../constants/statusMessage';
-import { Toast } from '../common';
+import { Pencil } from '../../assets/icons/common';
+import { fontSize } from '../../styles/Mixin';
 
 const UserInformation = () => {
   const setAuth = useSetRecoilState(authState);
@@ -28,7 +28,6 @@ const UserInformation = () => {
   const resetUserInfoState = useResetRecoilState(userState);
 
   const history = useHistory();
-
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
   const [deleteAccountModalOpen, setdeleteAccountModalOpen] = useState(false);
@@ -52,6 +51,7 @@ const UserInformation = () => {
           value: myPageData.monsterName,
         });
       }
+
       setIsEditModalOpen(true);
     },
     [myPageData.monsterName],
@@ -154,6 +154,11 @@ const UserInformation = () => {
           handleClick: () => history.push('/notice'),
         },
         {
+          title: '신고하기',
+          contents: '',
+          handleClick: () => window.open('구글폼주소', '_blank'),
+        },
+        {
           title: '로그아웃',
           contents: '',
           handleClick: () => setIsLogoutModalOpen(true),
@@ -174,11 +179,11 @@ const UserInformation = () => {
         <PageTitle>마이페이지</PageTitle>
       </TitleArea>
       <UserInfoWrap>
-        {/* <Mypage /> */}
+        <MonsterThumbnailWrapper thumbnailSize="small" monsterLevel={3} />
         <div>
           <BoldText>{myPageData.username}</BoldText>
-          <EditNicknameBtn onclick={() => openModal('username')}>
-            {/* <Pencil /> */}
+          <EditNicknameBtn onClick={() => openModal('username')}>
+            <Pencil />
           </EditNicknameBtn>
         </div>
         <Summary>

--- a/src/components/myPage/index.js
+++ b/src/components/myPage/index.js
@@ -1,5 +1,5 @@
 import UserInformation from './UserInformation';
 import EditBox from './EditBox';
-import FollowListItem from './FollowListItem';
+import UserInfoItem from './UserInfoItem';
 
-export { UserInformation, EditBox, FollowListItem };
+export { UserInformation, EditBox, UserInfoItem };

--- a/src/pages/Follow.js
+++ b/src/pages/Follow.js
@@ -2,9 +2,11 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory, useLocation, NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { FollowListItem } from '../components/myPage';
-import { BackButtonHeader } from '../components/common';
 import { myPageApis } from '../api';
+import { OK } from '../constants/statusCode';
+
+import { MonsterListItem } from '../components/monster';
+import { BackButtonHeader } from '../components/common';
 
 const FollowPage = () => {
   const history = useHistory();
@@ -25,50 +27,25 @@ const FollowPage = () => {
     if (!isCorrectTabType) return;
     console.log('tabType', tabType);
 
-    if (tabType === 'followers') {
-      const { data } = await myPageApis.loadFollowers();
-      if (data.statusCode === 200) {
-        console.log('followerdata', data, data.followers);
-        setFollowList(data.followers);
-      }
+    let getUserResponse = myPageApis.loadFollowers;
+
+    if (tabType === 'following') {
+      getUserResponse = myPageApis.loadFollowings;
     }
-    const { data } = await myPageApis.loadFollowings();
-    if (data.statusCode === 200) {
-      setFollowList(data.followings);
+
+    const { data } = await getUserResponse();
+
+    if (data.statusCode === OK) {
+      const followList =
+        tabType === 'followers' ? data.followers : data.followings;
+      console.log('followerdata', followList);
+      setFollowList(followList ?? []);
     }
   }, [tabType, isCorrectTabType]);
 
   useEffect(() => {
     getUserList();
   }, [getUserList]);
-  // const getFollowerList = async () => {
-  //   try {
-  //     const { data } = await myPageApis.loadFollowers();
-  //     if (data.statusCode === 200) {
-  //       console.log('followerdata', data, data.followers);
-  //       setFollowerList(data.followers);
-  //     }
-  //   } catch (error) {
-  //     console.log(error);
-  //   }
-  // };
-
-  // const getFollowingList = async () => {
-  //   try {
-  //     const { data } = await myPageApis.loadFollowings();
-  //     if (data.statusCode === 200) {
-  //       console.log('followingdata', data, data.followings);
-  //       setFollowingList(data.followings);
-  //     }
-  //   } catch (error) {
-  //     console.log(error);
-  //   }
-  // };
-
-  // useEffect(() => {
-  //   getFollowerList();
-  //   getFollowingList();
-  // }, []);
 
   //@jaekyung Todo. followlist 컴포넌트 만들어서 재활용하게 할 예정임
   return (
@@ -97,9 +74,10 @@ const FollowPage = () => {
         </NavButtonItem>
       </NavButtonWrap>
       <FollowListWrap>
-        {MOCK_DATA.map((user) => {
-          return <FollowListItem key={user.monsterCode} user={user} />;
-        })}
+        {followList?.length > 0 &&
+          followList.map((user) => {
+            return <MonsterListItem key={user.monsterCode} user={user} />;
+          })}
       </FollowListWrap>
     </FollowContainer>
   );
@@ -161,31 +139,5 @@ const NavButton = styled(NavLink)`
 const FollowListWrap = styled.ul`
   color: var(--color-primary);
   margin: 0;
-  padding: 0;
+  padding: 16px 0 0;
 `;
-
-// MOCK_DATA
-
-const MOCK_DATA = [
-  {
-    email: 'abc@gmail.com',
-    isFollowed: true,
-    monsterCode: '12345',
-    monsterImg: '',
-    monsterName: '뽁아리',
-  },
-  {
-    email: 'abc@gmail.com',
-    isFollowed: false,
-    monsterCode: '12395',
-    monsterImg: '',
-    monsterName: '뽁아리',
-  },
-  {
-    email: 'abc@gmail.com',
-    isFollowed: true,
-    monsterCode: '10345',
-    monsterImg: '',
-    monsterName: '뽁아리',
-  },
-];


### PR DESCRIPTION
몬스터썸네일래퍼로 그 이미지를 감싸고 있는 보더와 뱃지 사용할 수 있게 했습니다.
팔로우페이지는 쿼리스트링으로 탭타입에 따라서 데이터 받아오게 했습니다.
그리고 안에 있는 몬스터리스트아이템을 재활용할 수 있게 컴포넌트로 만들었습니다. 
상세유저로 가는 링크나 필요한 부분은 수정 부탁드립니다.
버튼에 팔로우 언팔로우하는 기능은 붙이지 않았습니다. 리스트 아이템에 온클릭 주셔서 수정해주시면 됩니당 감사합니다